### PR TITLE
Adds vendor:publish --tag=passport-config

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -184,10 +184,14 @@ If necessary, you may define the path where Passport's keys should be loaded fro
         Passport::loadKeysFrom('/secret-keys/oauth');
     }
 
-Additionally, you may load the keys from environment variables:
+Additionally, you may publish the passport config file using `php artisan vendor:publish --tag=passport-config` which will then load the keys from environment variables:
 
-    PASSPORT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n<private key here>\n-----END RSA PRIVATE KEY-----"
-    PASSPORT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n<public key here>\n-----END PUBLIC KEY-----\n"
+    PASSPORT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+    <private key here>
+    -----END RSA PRIVATE KEY-----"
+    PASSPORT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
+    <public key here>
+    -----END PUBLIC KEY-----"
 
 <a name="configuration"></a>
 ## Configuration


### PR DESCRIPTION
I found trying to use envs for the public and private keys in the Laravel Passport package only worked once the config has been published. Before that I would get complaints from the framework that the keys could not be found. 

Multiline ENVs are also supported by the dotenv library used by Laravel so I think it would be better to advertise that option rather than having to put it all on one line and inserting the new line characters.