### PR TITLE
[9.x] value helper function can use further parameters

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -4045,6 +4045,14 @@ The `value` function returns the value it is given. However, if you pass a closu
     });
 
     // false
+    
+Further parameters may be passed to the value function and if the first parameter is a closure these additional parameters will be passed to the closure.
+
+    $result = value(function ($parameter) {
+        return $parameter;
+    }, true);
+    
+    // true
 
 <a name="method-view"></a>
 #### `view()` {.collection-method}


### PR DESCRIPTION
Updated the docs for the `value` function to [reflect the fact additional parameters can be passed to the closure if one is provided as the first parameter](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Collections/helpers.php#L186-L189).